### PR TITLE
convert  header title into a link 

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
+import { Link } from "react-router-dom";
 export default function Header({ children }) {
   return (
     <>
       <div id="main-header-loading"></div>
       <header id="main-header">
         <div id="header-title">
-          <h1>Eadevs Events</h1>
+          <Link to="/"><h1>Eadevs Events</h1></Link>
         </div>
         <nav>{children}</nav>
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,10 @@ ul {
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.26);
 }
 
+#header-title a {
+  text-decoration: none;
+}
+
 #main-header nav {
   display: flex;
   gap: 1rem;
@@ -413,6 +417,7 @@ ul {
   height: 80px;
   margin: 1rem 0;
 }
+
 .lds-ring div {
   box-sizing: border-box;
   display: block;
@@ -425,12 +430,15 @@ ul {
   animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
   border-color: #e30d5b transparent transparent transparent;
 }
+
 .lds-ring div:nth-child(1) {
   animation-delay: -0.45s;
 }
+
 .lds-ring div:nth-child(2) {
   animation-delay: -0.3s;
 }
+
 .lds-ring div:nth-child(3) {
   animation-delay: -0.15s;
 }
@@ -439,6 +447,7 @@ ul {
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }
@@ -449,6 +458,7 @@ ul {
     opacity: 0;
     transform: translateY(-3rem);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);


### PR DESCRIPTION
convert  header title into a link pointing to the home page to help users navigate to home page from other pages like event detail page