### PR TITLE
fix: ensure query is enabled only for valid search terms

### DIFF
--- a/src/components/Events/FindEventSection.jsx
+++ b/src/components/Events/FindEventSection.jsx
@@ -12,7 +12,7 @@ export default function FindEventSection() {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["events", { searchTerm: searchTerm }],
     queryFn: ({ signal, queryKey }) => fetchEvents({ signal, ...queryKey[1] }),
-    enabled: searchTerm !== undefined,
+    enabled: !!searchTerm,
   });
 
   function handleSubmit(event) {


### PR DESCRIPTION
Updated the enabled condition in useQuery to use `enabled: !!searchTerm` for stricter validation of truthy search terms.
Earlier --> `enabled: searchTerm !== undefined` didn't work